### PR TITLE
fixed the spelling of Python

### DIFF
--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -23,7 +23,7 @@ export default function Experience() {
         "NodeJS",
         "Express",
         "MongoDB",
-        "Pyhton",
+        "Python",
         "Java",
         "Git",
         "Dart",


### PR DESCRIPTION
![image](https://github.com/dhanush17-tech/geekydan/assets/80093392/b980369d-44f0-46a7-8408-a334a67a90f7)

So Python was misspelled as Pyhton, fixed it for ya!